### PR TITLE
Changed the Header Label "Hub" to "Black Duck"

### DIFF
--- a/cmd/protoform-installer/frontend/client/src/InstanceTable.js
+++ b/cmd/protoform-installer/frontend/client/src/InstanceTable.js
@@ -49,7 +49,7 @@ const InstanceTable = ({ instances, classes, handleDelete }) => {
                         <TableCell>Namespace</TableCell>
                         <TableCell>Size</TableCell>
                         <TableCell>Backup Interval</TableCell>
-                        <TableCell>Hub Version</TableCell>
+                        <TableCell>Black Duck Version</TableCell>
                         <TableCell>Database</TableCell>
                         <TableCell>PVC Claim</TableCell>
                         <TableCell>IP Address</TableCell>


### PR DESCRIPTION
the main product formerly known as Hub is now just called Black Duck, change to line 52 reflects this.